### PR TITLE
Limpia filtros SIR antes de enviar formulario

### DIFF
--- a/main/webapp/jsp/registro/listadoRelacionAnotaciones.jsp
+++ b/main/webapp/jsp/registro/listadoRelacionAnotaciones.jsp
@@ -502,6 +502,12 @@
                 // Log para asegurarse de que todo está ok antes del submit
                 console.log("[seleccionRegistro] Form justo antes del submit:", document.forms[0]);
 
+                // Limpiamos los filtros SIR antes de enviar el formulario para evitar
+                // que se arrastren valores a altaRE.jsp y provoquen errores
+                document.getElementById('identificadorRegistroSIRValue').value = '';
+                document.getElementById('codEstadoSIR').value = '';
+                document.getElementById('codigoUnidadDestinoSIRHidden').value = '';
+
                 document.forms[0].submit();
             } //seleccionRegistro
 


### PR DESCRIPTION
## Summary
- limpia los campos `identificadorRegistroSIRValue`, `codEstadoSIR` y `codigoUnidadDestinoSIRHidden` al ejecutar `seleccionRegistro()`
- deja comentado el motivo de la limpieza para futuras referencias

## Testing
- `npm test` *(falla: falta package.json)*
- `mvn -q test` *(falla: no hay POM)*

------
https://chatgpt.com/codex/tasks/task_e_6876285238ec8329aa3779e87f15fac9